### PR TITLE
STM32duinoBLE enhancement

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -7,10 +7,9 @@ jobs:
    strategy:
      matrix:
        fqbn: [
-         "arduino:samd:mkrwifi1010",
-         "arduino:samd:nano_33_iot",
-         "arduino:megaavr:uno2018:mode=on",
-         "arduino:mbed:nano33ble"
+         '"STM32:stm32:Eval:pnum=STEVAL_MKSBOX1V1,usb=CDCgen" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"',
+         '"STM32:stm32:Nucleo_64:pnum=NUCLEO_L476RG" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"',
+         '"STM32:stm32:Disco:pnum=DISCO_L475VG_IOT" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"'
        ]
 
    steps:

--- a/examples/Peripheral/ButtonLED/ButtonLED.ino
+++ b/examples/Peripheral/ButtonLED/ButtonLED.ino
@@ -104,7 +104,7 @@ void loop() {
   char buttonValue = digitalRead(buttonPin);
 
   // has the value changed since the last read
-  boolean buttonChanged = (buttonCharacteristic.value() != buttonValue);
+  bool buttonChanged = (buttonCharacteristic.value() != buttonValue);
 
   if (buttonChanged) {
     // button state changed, update characteristics

--- a/src/BLETypedCharacteristics.h
+++ b/src/BLETypedCharacteristics.h
@@ -27,7 +27,7 @@ public:
   BLEBoolCharacteristic(const char* uuid, unsigned char properties);
 };
 
-class BLEBooleanCharacteristic : public BLETypedCharacteristic<boolean> {
+class BLEBooleanCharacteristic : public BLETypedCharacteristic<bool> {
 public:
   BLEBooleanCharacteristic(const char* uuid, unsigned char properties);
 };

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -1142,7 +1142,7 @@ void ATTClass::readByTypeResp(uint16_t connectionHandle, uint8_t dlen, uint8_t d
 
 void ATTClass::writeReqOrCmd(uint16_t connectionHandle, uint16_t mtu, uint8_t op, uint8_t dlen, uint8_t data[])
 {
-  boolean withResponse = (op == ATT_OP_WRITE_REQ);
+  bool withResponse = (op == ATT_OP_WRITE_REQ);
 
   if (dlen < sizeof(uint16_t)) {
     if (withResponse) {

--- a/src/utility/HCISpiTransport.cpp
+++ b/src/utility/HCISpiTransport.cpp
@@ -21,15 +21,14 @@
 
 volatile int data_avail = 0;
 
-HCISpiTransportClass::HCISpiTransportClass(SPIClass& spi, BLEChip_t ble_chip, uint8_t cs_pin, uint8_t spi_irq, uint8_t ble_rst, unsigned long frequency, int spi_mode) :
+HCISpiTransportClass::HCISpiTransportClass(SPIClass& spi, BLEChip_t ble_chip, uint8_t cs_pin, uint8_t spi_irq, uint8_t ble_rst, uint32_t frequency, uint8_t spi_mode) :
   _spi(&spi),
   _ble_chip(ble_chip),
   _cs_pin(cs_pin),
   _spi_irq(spi_irq),
-  _ble_rst(ble_rst),
-  _frequency(frequency),
-  _spi_mode(spi_mode)
+  _ble_rst(ble_rst)
 {
+  _spiSettings = SPISettings(frequency, (BitOrder)BLE_SPI_BYTE_ORDER, spi_mode);
   _read_index = 0;
   _write_index = 0;
   _write_index_initial = 0;
@@ -125,7 +124,7 @@ int HCISpiTransportClass::available()
         detachInterrupt(_spi_irq);
       }
 
-      _spi->beginTransaction(SPISettings(_frequency, MSBFIRST, _spi_mode));
+      _spi->beginTransaction(_spiSettings);
 
       digitalWrite(_cs_pin, LOW);
 
@@ -337,7 +336,7 @@ size_t HCISpiTransportClass::write(const uint8_t* data, size_t length)
     {
       result = 0;
 
-      _spi->beginTransaction(SPISettings(_frequency, MSBFIRST, _spi_mode));
+      _spi->beginTransaction(_spiSettings);
 
       digitalWrite(_cs_pin, LOW);
 
@@ -376,7 +375,7 @@ size_t HCISpiTransportClass::write(const uint8_t* data, size_t length)
 
       detachInterrupt(_spi_irq);
 
-      _spi->beginTransaction(SPISettings(_frequency, MSBFIRST, _spi_mode));
+      _spi->beginTransaction(_spiSettings);
 
       digitalWrite(_cs_pin, LOW);
 
@@ -458,7 +457,7 @@ void HCISpiTransportClass::wait_for_blue_initialize()
     {
       uint8_t header_master[5] = {0x0b, 0x00, 0x00, 0x00, 0x00};
 
-      _spi->beginTransaction(SPISettings(_frequency, MSBFIRST, _spi_mode));
+      _spi->beginTransaction(_spiSettings);
 
       digitalWrite(_cs_pin, LOW);
 
@@ -526,7 +525,7 @@ void HCISpiTransportClass::wait_for_enable_ll_only()
     {
       uint8_t header_master[5] = {0x0b, 0x00, 0x00, 0x00, 0x00};
 
-      _spi->beginTransaction(SPISettings(_frequency, MSBFIRST, _spi_mode));
+      _spi->beginTransaction(_spiSettings);
 
       digitalWrite(_cs_pin, LOW);
 
@@ -580,7 +579,7 @@ void HCISpiTransportClass::enable_ll_only()
   {
     result = 0;
 
-    _spi->beginTransaction(SPISettings(_frequency, MSBFIRST, _spi_mode));
+    _spi->beginTransaction(_spiSettings);
 
     digitalWrite(_cs_pin, LOW);
 

--- a/src/utility/HCISpiTransport.h
+++ b/src/utility/HCISpiTransport.h
@@ -29,11 +29,14 @@ typedef enum BLEChip_s {
   BLUENRG_M2SP
 } BLEChip_t;
 
+#ifndef BLE_SPI_BYTE_ORDER
+#define BLE_SPI_BYTE_ORDER  MSBFIRST
+#endif
 #define BLE_MODULE_SPI_BUFFER_SIZE 128
 
 class HCISpiTransportClass : public HCITransportInterface {
 public:
-  HCISpiTransportClass(SPIClass& spi, BLEChip_t ble_chip, uint8_t cs_pin, uint8_t spi_irq, uint8_t ble_rst, unsigned long frequency, int spi_mode);
+  HCISpiTransportClass(SPIClass& spi, BLEChip_t ble_chip, uint8_t cs_pin, uint8_t spi_irq, uint8_t ble_rst, uint32_t frequency, uint8_t spi_mode);
   virtual ~HCISpiTransportClass();
 
   virtual int begin();
@@ -52,12 +55,11 @@ private:
   void wait_for_enable_ll_only();
   void enable_ll_only();
   SPIClass* _spi;
+  SPISettings _spiSettings;
   BLEChip_t _ble_chip;
   uint8_t _cs_pin;
   uint8_t _spi_irq;
   uint8_t _ble_rst;
-  unsigned long _frequency;
-  int _spi_mode;
   uint8_t _rxbuff[BLE_MODULE_SPI_BUFFER_SIZE];
   uint16_t _read_index;
   uint16_t _write_index;


### PR DESCRIPTION
Hi @cparata 
here some update I've made to extend robustness and flexibility:
* Replace boolean with standard bool:  avoid several warnings
* SPISettings managements: instead of storing the frequency and mode. Store directly the `SPISettings` and avoid to construct it each time a `beginTransaction` is called.